### PR TITLE
Add HTML table and <caption> support for HTML-to-LaTeX conversion

### DIFF
--- a/include/html2tex.h
+++ b/include/html2tex.h
@@ -46,6 +46,7 @@ extern "C" {
 		
         int table_columns;
         int current_column;
+		char* table_caption;
     };
 
     /* main converter structure */

--- a/source/html2tex.c
+++ b/source/html2tex.c
@@ -25,8 +25,9 @@ LaTeXConverter* html2tex_create(void) {
     converter->state.table_columns = 0;
 
     converter->state.current_column = 0;
-    converter->error_code = 0;
+    converter->state.table_caption = NULL;
 
+    converter->error_code = 0;
     converter->error_message[0] = '\0';
     return converter;
 }
@@ -46,6 +47,12 @@ char* html2tex_convert(LaTeXConverter* converter, const char* html) {
 
     converter->error_code = 0;
     converter->error_message[0] = '\0';
+
+    /* free any existing caption */
+    if (converter->state.table_caption) {
+        free(converter->state.table_caption);
+        converter->state.table_caption = NULL;
+    }
 
     /* add LaTeX document preamble */
     append_string(converter, "\\documentclass{article}\n");
@@ -89,6 +96,10 @@ const char* html2tex_get_error_message(const LaTeXConverter* converter) {
 
 void html2tex_destroy(LaTeXConverter* converter) {
     if (!converter) return;
+
+    /* free table caption if it exists */
+    if (converter->state.table_caption)
+        free(converter->state.table_caption);
 
     if (converter->output)
         free(converter->output);


### PR DESCRIPTION
Introduce full support for converting **HTML** tables and their **caption** 
elements to **LaTeX**,  enabling more accurate and complete table rendering.